### PR TITLE
sony: satsuki: Decrease screen size from large to normal

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -61,7 +61,7 @@ PRODUCT_PACKAGES += \
     InCallUI \
     Stk
 
-PRODUCT_AAPT_CONFIG := large
+PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 


### PR DESCRIPTION
Use the baseline configuration (which is normal size).

References:

```
Bullhead 5.2"
https://android.googlesource.com/device/lge/bullhead/+/android-6.0.1_r63/device.mk#141

Angler 5.7"
https://android.googlesource.com/device/huawei/angler/+/android-6.0.1_r63/device.mk#142
```

Docs:

```
https://developer.android.com/guide/practices/screens_support.html#range
```

Signed-off-by: Humberto Borba humberos@gmail.com
