### PR TITLE
satsuki: remove 8/23MP Switch in ES

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -72,10 +72,6 @@ PRODUCT_PROPERTY_OVERRIDES := \
     ro.sf.lcd_density=480 \
     ro.usb.pid_suffix=1DB
 
-## 8MP Switch for ES
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.camera.8mp.config=true
-
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/kitakami/platform.mk)
 $(call inherit-product, vendor/sony/kitakami-satsuki/satsuki-vendor.mk)


### PR DESCRIPTION
was removed on https://github.com/sonyxperiadev/device-sony-kitakami/commit/8f8f66c2cfb93df82e246b453c9cabdc2cd16e91

Signed-off-by: David Viteri <davidteri91@gmail.com>